### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-bill/main.go
+++ b/cmd/baton-bill/main.go
@@ -53,6 +53,7 @@ func getConnector(ctx context.Context, c *cfg.Bill) (types.ConnectorServer, erro
 			Password:     c.Password,
 			DeveloperKey: c.Developerkey,
 		},
+		c.BaseUrl,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/bill/client.go
+++ b/pkg/bill/client.go
@@ -27,10 +27,6 @@ type Client struct {
 	Credentials
 }
 
-func (c *Client) loginURL() string {
-	return c.baseURL + "/Login.json"
-}
-
 func (c *Client) usersURL() string {
 	return c.baseURL + "/List/User.json"
 }

--- a/pkg/bill/client.go
+++ b/pkg/bill/client.go
@@ -11,17 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const SandboxBaseURL = "https://api-sandbox.bill.com/api/v2"
-const BaseURL = "https://api.bill.com/api/v2"
-
-// usual format: <API_Base_URL>/Crud/<Operation>/<Entity>.json (Read more at https://developer.bill.com/docs/api-request-format)
-const LoginBaseURL = BaseURL + "/Login.json"
-const UsersBaseURL = BaseURL + "/List/User.json"
-const OrganizationsBaseURL = BaseURL + "/ListOrgs.json"
-const UserRoleProfileBaseURL = BaseURL + "/Crud/Read/Profile.json"
-const UserRoleProfilesBaseURL = BaseURL + "/List/Profile.json"
-const UserRolePermissionsBaseURL = BaseURL + "/GetProfilePermissions.json"
-const ApiSessionBaseURL = BaseURL + "/GetSessionInfo.json"
+const DefaultBaseURL = "https://api.bill.com/api/v2"
 
 type Credentials struct {
 	Username       string
@@ -33,7 +23,32 @@ type Credentials struct {
 
 type Client struct {
 	httpClient *http.Client
+	baseURL    string
 	Credentials
+}
+
+func (c *Client) loginURL() string {
+	return c.baseURL + "/Login.json"
+}
+
+func (c *Client) usersURL() string {
+	return c.baseURL + "/List/User.json"
+}
+
+func (c *Client) organizationsURL() string {
+	return c.baseURL + "/ListOrgs.json"
+}
+
+func (c *Client) userRoleProfileURL() string {
+	return c.baseURL + "/Crud/Read/Profile.json"
+}
+
+func (c *Client) userRoleProfilesURL() string {
+	return c.baseURL + "/List/Profile.json"
+}
+
+func (c *Client) userRolePermissionsURL() string {
+	return c.baseURL + "/GetProfilePermissions.json"
 }
 
 type LoginResponse = BaseResponse[LoginData]
@@ -49,9 +64,13 @@ type UserParams struct {
 	SearchParams
 }
 
-func NewClient(httpClient *http.Client, credentials Credentials) *Client {
+func NewClient(httpClient *http.Client, credentials Credentials, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &Client{
 		httpClient:  httpClient,
+		baseURL:     baseURL,
 		Credentials: credentials,
 	}
 }
@@ -63,7 +82,7 @@ func (c *Client) Login(ctx context.Context, organizationId string) error {
 	// Setup required organization id for client
 	c.OrganizationId = organizationId
 
-	err := c.doRequest(ctx, UsersBaseURL, &loginResponse, c.Credentials, nil, nil)
+	err := c.doRequest(ctx, c.usersURL(), &loginResponse, c.Credentials, nil, nil)
 
 	if err != nil {
 		return err
@@ -87,7 +106,7 @@ func (c *Client) GetOrganizations(ctx context.Context) ([]Organization, error) {
 
 	err := c.doRequest(
 		ctx,
-		OrganizationsBaseURL,
+		c.organizationsURL(),
 		&organizationsResponse,
 		Credentials{
 			DeveloperKey: c.DeveloperKey,
@@ -115,7 +134,7 @@ func (c *Client) GetSessionDetails(ctx context.Context) (SessionDetails, error) 
 
 	err := c.doRequest(
 		ctx,
-		UsersBaseURL,
+		c.usersURL(),
 		&sessionDetailsResponse,
 		Credentials{
 			DeveloperKey: c.DeveloperKey,
@@ -142,7 +161,7 @@ func (c *Client) GetUsers(ctx context.Context, getUsersVars PaginationParams) ([
 
 	err := c.doRequest(
 		ctx,
-		UsersBaseURL,
+		c.usersURL(),
 		&usersResponse,
 		Credentials{
 			DeveloperKey: c.DeveloperKey,
@@ -169,7 +188,7 @@ func (c *Client) GetUserRoleProfiles(ctx context.Context, getUserRoleProfilesVar
 
 	err := c.doRequest(
 		ctx,
-		UserRoleProfilesBaseURL,
+		c.userRoleProfilesURL(),
 		&userRoleProfilesResponse,
 		Credentials{
 			DeveloperKey: c.DeveloperKey,
@@ -196,7 +215,7 @@ func (c *Client) GetUserRoleProfile(ctx context.Context, roleId string) (UserRol
 
 	err := c.doRequest(
 		ctx,
-		UserRoleProfileBaseURL,
+		c.userRoleProfileURL(),
 		&userRoleProfileResponse,
 		Credentials{
 			DeveloperKey: c.DeveloperKey,
@@ -223,7 +242,7 @@ func (c *Client) GetUserRolePermissions(ctx context.Context, roleId string) (map
 
 	err := c.doRequest(
 		ctx,
-		UserRolePermissionsBaseURL,
+		c.userRolePermissionsURL(),
 		&userRolePermissionsResponse,
 		Credentials{
 			DeveloperKey: c.DeveloperKey,

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Bill struct {
 	Password string `mapstructure:"password"`
 	Organizationids []string `mapstructure:"organizationIds"`
 	Developerkey string `mapstructure:"developerKey"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Bill) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Bill API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,10 @@ var (
 		field.WithRequired(true),
 		field.WithIsSecret(true),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Bill API URL (for testing)"),
+	)
 )
 
 //go:generate go run ./gen
@@ -38,4 +42,5 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	Password,
 	OrganizationIDs,
 	DeveloperKey,
+	BaseURLField,
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Bill API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -65,14 +65,14 @@ func (b *Bill) Validate(ctx context.Context) (annotations.Annotations, error) {
 }
 
 // New returns the Bill connector.
-func New(ctx context.Context, organizationIDs []string, credentials bill.Credentials) (*Bill, error) {
+func New(ctx context.Context, organizationIDs []string, credentials bill.Credentials, baseURL string) (*Bill, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 
 	if err != nil {
 		return nil, err
 	}
 
-	billClient := bill.NewClient(httpClient, credentials)
+	billClient := bill.NewClient(httpClient, credentials, baseURL)
 
 	return &Bill{
 		client: billClient,


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-bill/main.go,pkg/bill/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-bill --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bill API base URL is now configurable via configuration/CLI, letting you override the default endpoint for testing or alternative environments.
  * All API calls now honor the configured base URL.
  * Enhanced API responses with new standardized response types for more consistent and reliable data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->