### PR TITLE
fix: do not mutate Client.OrganizationId on Login failure

### DIFF
--- a/pkg/bill/client.go
+++ b/pkg/bill/client.go
@@ -75,10 +75,13 @@ func NewClient(httpClient *http.Client, credentials Credentials, baseURL string)
 func (c *Client) Login(ctx context.Context, organizationId string) error {
 	var loginResponse LoginResponse
 
-	// Setup required organization id for client
-	c.OrganizationId = organizationId
+	// Build the request credentials with the target org id without mutating
+	// the client; we only commit the new org/session to c on success so a
+	// failed login does not leave the client half-updated.
+	reqCreds := c.Credentials
+	reqCreds.OrganizationId = organizationId
 
-	err := c.doRequest(ctx, c.usersURL(), &loginResponse, c.Credentials, nil, nil)
+	err := c.doRequest(ctx, c.usersURL(), &loginResponse, reqCreds, nil, nil)
 
 	if err != nil {
 		return err
@@ -88,7 +91,6 @@ func (c *Client) Login(ctx context.Context, organizationId string) error {
 		return status.Error(400, "Request failed")
 	}
 
-	// modify the client credentials to involve new session id and organization id
 	c.SessionId = loginResponse.Data.SessionId
 	c.OrganizationId = loginResponse.Data.OrgId
 


### PR DESCRIPTION
## what changed

`Client.Login` set `c.OrganizationId = organizationId` before sending the auth request. If the request errored or the response was invalid, the function returned without unwinding, so the client was left with the new `OrganizationId` paired with whatever `SessionId` was there before.

`c.Credentials` is the request body source (Bill's API takes credentials as form-encoded fields), so the org id has to be in scope for the request itself. The change builds a local copy of `c.Credentials`, sets the target org on the copy, and passes it to `doRequest`. The client struct only gets the new `OrganizationId` and `SessionId` after the response is validated.

## why this matters

A failed `Login` previously left the `Client` in a half-updated state that callers could observe -- old session, new org. Subsequent calls on that client would issue requests authenticated for the previous session against the new org.

## how I found this

Static analysis with [occult-go-analysis](https://github.com/conductorone/occult-go-analysis), c1 profile, `abstract_state_leak_on_error_path` detector.